### PR TITLE
CoH new years drinks; Add names to attendance list 2024

### DIFF
--- a/alumni.ch.tudelft.nl/index.html@p=735_2024.html
+++ b/alumni.ch.tudelft.nl/index.html@p=735_2024.html
@@ -459,11 +459,28 @@ body.custom-background { background-color: #eff4fc; }
 <hr class="wp-block-separator"/>
 
 
-<!-- TODO fill the attendance list
-<p><strong>Attendance list (Updated 10/01/2023)</strong></p>
+<p><strong>Attendance list (Updated 04/01/2023)</strong></p>
 
-<p>Example Name<br>Example Name</p>
--->
+<p>
+	Frans Ververs<br>
+	Yorick de Vries<br>
+	Luca Hagemans<br>
+	Max Rensen<br>
+	Daniel de Klein<br>
+	Robert ten Hoor<br>
+	Steffan Norberhuis<br>
+	Hans van den bogert<br>
+	Leon Rothkrantz<br>
+	Bhoomika Agarwal<br>
+	Daniel Gieskens<br>
+	Ank Voets<br>
+	Friso Abcouwer<br>
+	Jasper Abbink<br>
+	Joost de Groot<br>
+	Boaz van der Vlugt<br>
+	Peter Kluit<br>
+	Sterre Lutz
+</p>
 
 							</div><!-- .entry-content -->
 

--- a/alumni.ch.tudelft.nl/index.html@p=735_2024.html
+++ b/alumni.ch.tudelft.nl/index.html@p=735_2024.html
@@ -427,7 +427,7 @@ body.custom-background { background-color: #eff4fc; }
 					<h1 class="entry-title">New Year&#8217;s drinks - January 19th 2024</h1>
 		
 				<div class="entry-meta">
-			<h5 class="entry-date"><i class="fa fa-calendar-o"></i> <a href="index.html@p=735.html" title="4:22 pm" rel="bookmark"><time class="entry-date" datetime="2023-01-03T16:22:12+01:00" pubdate>January 3, 2023 </time></a><span class="byline"><span class="sep"></span><i class="fa fa-user"></i>
+			<h5 class="entry-date"><i class="fa fa-calendar-o"></i> <a href="index.html@p=735.html" title="4:22 pm" rel="bookmark"><time class="entry-date" datetime="2023-11-22T16:22:12+01:00" pubdate>November 23, 2023 </time></a><span class="byline"><span class="sep"></span><i class="fa fa-user"></i>
 <span class="author vcard"><a class="url fn n" href="author/admin/index.html" title="View all posts by admin" rel="author">admin</a></span></span></h5>
 		</div><!-- .entry-meta -->
 			</header><!-- .entry-header -->
@@ -459,7 +459,7 @@ body.custom-background { background-color: #eff4fc; }
 <hr class="wp-block-separator"/>
 
 
-<p><strong>Attendance list (Updated 04/01/2023)</strong></p>
+<p><strong>Attendance list (Updated 04/01/2024)</strong></p>
 
 <p>
 	Frans Ververs<br>


### PR DESCRIPTION
Hey!

This PR will add the names of people attending the CoH New Year's drinks 2024 as of 04-01-2024
Please note: All people included on this list gave explicit permission to have their name published on the online attendance list.

Thanks,
Sven.